### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 Join the numbers and get to the 2048 tile!
 
-[![2048 with Kivy](https://developer.android.com/images/brand/en_generic_rgb_wo_45.png)](https://play.google.com/store/apps/details?id=com.meltingrocks.kivy2048)
+<a href='https://play.google.com/store/apps/details?id=com.meltingrocks.kivy2048&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png'/></a>
 
 This game has been created from the game 2048 by [Gabriele
 Cirulli](http://gabrielecirulli.com/), itself based on [1024 by Veewo
 Studio](https://itunes.apple.com/us/app/1024!/id823499224) conceptually similar
 to [Threes by Asher Vollmer.](http://asherv.com/threes/).
 
-This implementation use only Kivy framework, and can be played on mobile with
+This implementation uses only Kivy framework, and can be played on mobile with
 swipes or desktop with keyboard.
 
 ![Screenshot](/screenshot.png)
+
+
+Google Play and the Google Play logo are trademarks of Google Inc.


### PR DESCRIPTION
- Fixed typo. 

- Google Play logo as described [here](https://play.google.com/intl/en_us/badges/) states that we should:  

> Never use out-of-date badges 

> Include the appropriate Google Play legal attribution when there is space in the creative. See the badge generator for localized legal attributions. 

So I added those as well. (I probably didn't mess up anything :P )